### PR TITLE
feat(player): clamp player inside screen bounds

### DIFF
--- a/Assets/_Project/Scenes/Main.unity
+++ b/Assets/_Project/Scenes/Main.unity
@@ -390,6 +390,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b0246752b06dab84dbc4d3b11d2ee8f4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::PlayerController
+  moveSpeed: 5
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Assets/_Project/Scripts/PlayerController.cs
+++ b/Assets/_Project/Scripts/PlayerController.cs
@@ -2,7 +2,13 @@ using UnityEngine;
 
 public class PlayerController : MonoBehaviour
 {
-     [SerializeField] private float moveSpeed = 5f;
+    [SerializeField] private float moveSpeed = 5f;
+
+    [Header("Screen Boundaries")]
+    [SerializeField] private float minX = -8f;
+    [SerializeField] private float maxX = 8f;
+    [SerializeField] private float minY = -4f;
+    [SerializeField] private float maxY = 4f;
 
     private void Start()
     {
@@ -21,5 +27,15 @@ public class PlayerController : MonoBehaviour
         Vector2 movementDirection = new Vector2(horizontalInput, verticalInput).normalized;
 
         transform.Translate(movementDirection * moveSpeed * Time.deltaTime);
+
+        ClampPosition();
+    }
+
+    private void ClampPosition()
+    {
+        float clampedX = Mathf.Clamp(transform.position.x, minX, maxX); // Take the `value`, but force it to stay between `min` and `max`.
+        float clampedY = Mathf.Clamp(transform.position.y, minY, maxY);
+
+        transform.position = new Vector3(clampedX, clampedY, transform.position.z);
     }
 }


### PR DESCRIPTION
## What
Add screen boundary logic to keep the Player inside the visible game area.

## Why
This prevents the player ship from leaving the playable screen.

Closes #25 